### PR TITLE
Lxd share folder

### DIFF
--- a/daylight.sh
+++ b/daylight.sh
@@ -1568,6 +1568,28 @@ list-vms ()
 }
 
 
+lxd-instance-exists ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 1 )) || { printf 'Usage: lxc-instance-exists $container\n' >&2; return 1; }
+    local name=$1
+    lxc query "/1.0/instances/$name" >/dev/null 2>&1
+}
+
+lxd-share-folder ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 4 )) || { printf 'Usage: lxd-share-folder $container $share $srcDir $dstDir\n' >&2; return 1; }
+    local container=$1
+    lxd-instance-exists  "$container" || { printf 'Non-existent container: %s\n' "$container"; return 1; }
+    local share=$2
+    local srcDir=$3
+    [[ -d "$srcDir" ]] || { echo "Non-existent folder: $srcDir" >&2; return 1; }
+    local dstDir=$4
+    lxc config device add "$container" "$share" disk source="$srcDir" path="$dstDir"
+}
+
+
 prep-filesystem ()
 {
     mkdir -p /etc/nginx/streams.d/

--- a/daylight.sh
+++ b/daylight.sh
@@ -540,6 +540,22 @@ download-app ()
 
 
 #
+# Download daylight script from the specified branch
+#
+download-daylight ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 2 )) || { printf 'Usage: download-daylight $branch $dstFolder\n' >&2; return 1; }
+    local branch=$1
+    local dstFolder=$2
+    [[ -d "$dstFolder" ]] || { echo "Non-existent folder: $dstFolder" >&2; return 1; }
+    local org=daylight-public
+    local repo=daylight
+    url="https://raw.githubusercontent.com/$org/$repo/$branch/daylight.sh"
+    curl --location --silent --output-dir "$dstFolder" --remote-name "$url"
+}
+
+#
 # Download the entire dist folder from S3 to /tmp/dist
 #
 download-dist ()
@@ -1632,6 +1648,8 @@ pull-app ()
 
 #
 # Download and source the latest daylight.sh from S3. Crucial for debugging.
+#
+# DEPRECATED - use download-daylight instead
 #
 pull-daylight ()
 {


### PR DESCRIPTION
A simple function to support sharing a folder from a host to a container. 

This change includes a couple helper functions

`download-daylight` -- unrelated function to download `daylight.sh` based on branch
`lxd-instance-exists` -- useful function to determine if a container exists