### PR TITLE
Dump id map

### DIFF
--- a/daylight.sh
+++ b/daylight.sh
@@ -1591,6 +1591,15 @@ lxd-dump-id-map ()
 }
 
 
+lxd-instance-exists ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 1 )) || { printf 'Usage: lxc-instance-exists $container\n' >&2; return 1; }
+    local name=$1
+    lxc query "/1.0/instances/$name" >/dev/null 2>&1
+}
+
+
 lxd-set-id-map ()
 {
     # shellcheck disable=SC2016
@@ -1601,13 +1610,8 @@ lxd-set-id-map ()
     lxc config set "$container" raw.idmap - < <(sort "$idMapPath" | uniq)
     lxc restart "$container" 2>/dev/null || lxc start "$container"
     lxc exec "$container" -- cloud-init status --wait
-lxd-instance-exists ()
-{
-    # shellcheck disable=SC2016
-    (( $# == 1 )) || { printf 'Usage: lxc-instance-exists $container\n' >&2; return 1; }
-    local name=$1
-    lxc query "/1.0/instances/$name" >/dev/null 2>&1
 }
+
 
 lxd-share-folder ()
 {

--- a/daylight.sh
+++ b/daylight.sh
@@ -172,17 +172,12 @@ add-user-to-idmap ()
     local container=$2
 
     # Get id-map for the container, concatenate rows to it for the new user, update the idmap
-    local newIdMap; newIdMap=$(mktemp) || return
-    lxc query "/1.0/containers/$container" | jq -r '.expanded_config["raw.idmap"] // empty' | awk NF > "$newIdMap"
-
     local uid; uid=$(id --user "$username") || return
     local gid; gid=$(id --group "$username") || return
-    printf 'uid %d %d\n' "$uid" "$uid" >> "$newIdMap"
-    printf 'gid %d %d\n' "$gid" "$gid" >> "$newIdMap"
-
-    lxc config set "$container" raw.idmap - < <(sort "$newIdMap" | uniq)
-    lxc restart "$container" 2>/dev/null || lxc start "$container"
-    lxc exec "$container" -- cloud-init status --wait
+    local idMapPath; idMapPath=$(lxd-dump-id-map) || return
+    printf 'uid %d %d\n' "$uid" "$uid" >> "$idMapPath"
+    printf 'gid %d %d\n' "$gid" "$gid" >> "$idMapPath"
+    lxd-set-id-map "$container" "$idMapPath"
 }
 
 
@@ -1565,6 +1560,31 @@ list-vms ()
 {
     local bucket; bucket=$(get-bucket) || return
     aws s3api list-objects --bucket "$bucket" --prefix 'dist/vm' --query 'Contents[].Key[]' | jq -r '.[] | match("^dist/vm/(.*)\\.tgz$").captures[0].string' || return
+}
+
+
+lxd-dump-id-map ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 1 )) || { printf 'Usage: lxd-dump-id-map $container\n' >&2; return 1; }
+    local container=$1
+
+    local idMapPath; idMapPath=$(create-temp-file "$container.idmap.XXXXXX") || return
+    lxc query "/1.0/containers/$container" | jq -r '.expanded_config["raw.idmap"] // empty' | awk NF > "$idMapPath"
+    printf '%s' "$idMapPath"
+}
+
+
+lxd-set-id-map ()
+{
+    # shellcheck disable=SC2016
+    (( $# == 2 )) || { printf 'Usage: lxd-set-id-map $container $idMapPath\n' >&2; return 1; }
+    local container=$1
+    local idMapPath=$2
+
+    lxc config set "$container" raw.idmap - < <(sort "$idMapPath" | uniq)
+    lxc restart "$container" 2>/dev/null || lxc start "$container"
+    lxc exec "$container" -- cloud-init status --wait
 }
 
 

--- a/daylight.sh
+++ b/daylight.sh
@@ -174,7 +174,7 @@ add-user-to-idmap ()
     # Get id-map for the container, concatenate rows to it for the new user, update the idmap
     local uid; uid=$(id --user "$username") || return
     local gid; gid=$(id --group "$username") || return
-    local idMapPath; idMapPath=$(lxd-dump-id-map) || return
+    local idMapPath; idMapPath=$(lxd-dump-id-map "$container") || return
     printf 'uid %d %d\n' "$uid" "$uid" >> "$idMapPath"
     printf 'gid %d %d\n' "$gid" "$gid" >> "$idMapPath"
     lxd-set-id-map "$container" "$idMapPath"

--- a/lxd-id-maps.md
+++ b/lxd-id-maps.md
@@ -7,7 +7,7 @@ This means uid 0 = uid 100000 in the container and eg uid 1000 = 101000.
 Anything mapped into the container that is not owned by one of these
 high-number uids will appear in the container as uid/gid = -1, or nobody/nogroup.
 
-Sometimes this isn't the best.
+Sometimes this isn't what you want.
 
 For one, it can be nice for ubuntu (uid 1000) on the host to act as ubuntu in the container as well.
 
@@ -15,5 +15,6 @@ For two, I _think_ there might be some issues with ssh. It might not be possible
 
 Linux has a facility to help with some of this: the shadow subsystem, notably the /etc/subuid and /etc/subgid. Each row in /etc/sub(ug)id is of the form user:baseid:numids. Each of these rows defines a range of userids that the user is able to control.
 
-
+### How to play with id maps
+To have any visibility into what's going on with id maps, the best thing to do is to share a folder from the host VM with an lxd container, and create files on the shared folder from both the host and the container. Playing with this, in conjunction with playing with id maps, is a great way to develop intuition.
 


### PR DESCRIPTION
Nice utility method to handle the cruft of adding uid+gid info to the idmap for a container

This has been tested for idempotency. Adding a user to a container multuple times is safe.