### PR TITLE
Raise github-release-select-platform from the dead

### DIFF
--- a/daylight.sh
+++ b/daylight.sh
@@ -2447,6 +2447,27 @@ github-release-select ()
 
 
 
+
+
+
+github-release-select-platform ()
+{
+    # parse github args
+    local -A argmap=()
+    local nargs=0
+    github-parse-args argmap nargs "$@" || return
+    shift "$nargs"
+	# shellcheck disable=SC2016
+	(( $# = 2 )) || { printf 'Usage: github-release-select-platforms [flags] $org $repo' >&2; return 1; }
+    local platforms
+    readarray -t -d $'\n' platforms < <(github-release-list-platforms "$@")
+	select platform in "${platforms[@]}"; do
+        printf '%s' "$platform" || return
+        break
+    done
+}
+
+
 # Simple attempt to get info for a repo
 # If it does not succeed, it could mean the org or repo are nonexistent or misspelled
 # But it could also mean that the repo is non-public and requires a token for authentication
@@ -4954,6 +4975,7 @@ main ()
             github-install-latest-release) github-release-install "$@";;
             github-parse-args) github-parse-args "$@";;
             github-release-get-latest-tag) github-release-get-latest-tag "$@";;
+            github-release-select-platform) github-release-select-platform "$@";;
             github-test-repo) github-test-repo "$@";;
             github-test-repo-with-auth) github-test-repo-with-auth "$@";;
             go-service-gen-nginx-domain-file) go-service-gen-nginx-domain-file "$@";;


### PR DESCRIPTION
Restores `github-release-select-platform` that was deleted in 3c7c021 as dead code, with its case entry wired in the main dispatch. For archival reference only — do not merge.