### PR TITLE
Extract github-* functions and add CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+github-utils.sh    @github-actions

--- a/.github/workflows/generate-github-utils.yml
+++ b/.github/workflows/generate-github-utils.yml
@@ -1,0 +1,17 @@
+name: Generate github-utils.sh
+
+on:
+  push:
+    branches: [main]
+    paths: [daylight.sh]
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./extract-github-funcs.sh > github-utils.sh
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Regenerate github-utils.sh from daylight.sh"
+          file_pattern: github-utils.sh

--- a/.github/workflows/validate-github-utils.yml
+++ b/.github/workflows/validate-github-utils.yml
@@ -1,0 +1,13 @@
+name: Validate github-utils.sh
+
+on:
+  pull_request:
+    paths: [github-utils.sh, daylight.sh]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./extract-github-funcs.sh > /tmp/github-utils.sh
+      - run: diff /tmp/github-utils.sh github-utils.sh

--- a/daylight.sh
+++ b/daylight.sh
@@ -2403,6 +2403,35 @@ github-curl-post ()
 
 #-------------------------------------------------------------------------------
 #
+# github-detect-platform()
+#
+# Detect the OS and architecture as a platform string
+#
+github-detect-platform ()
+{
+    (( $# == 0 )) || { printf 'Usage: github-detect-platform\n' >&2; return 1; }
+    local os arch
+
+    case "$(uname -s)" in
+        Linux)                     os="linux" ;;
+        Darwin)                    os="darwin" ;;
+        MINGW*|MSYS*|CYGWIN*)     os="windows" ;;
+        *) printf 'Unsupported OS: %s\n' "$(uname -s)" >&2; return 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)             arch="amd64" ;;
+        aarch64|arm64)            arch="arm64" ;;
+        armv7l|armv6l)            arch="arm" ;;
+        *) printf 'Unsupported architecture: %s\n' "$(uname -m)" >&2; return 1 ;;
+    esac
+
+    printf '%s-%s' "$os" "$arch"
+}
+
+
+#-------------------------------------------------------------------------------
+#
 # github-download-latest-release()
 #
 # Download the latest release asset from a GitHub repository
@@ -6274,6 +6303,7 @@ main ()
             github-app-get-client-id)                 github-app-get-client-id "$@";;
             github-app-get-id)                        github-app-get-id "$@";;
             github-create-user-access-token)          github-create-user-access-token "$@";;
+            github-detect-platform)                   github-detect-platform "$@";;
             github-download-latest-release)           github-download-latest-release "$@";;
             github-get-release-name-list)             github-get-release-name-list "$@";;
             github-release-install)                   github-release-install "$@";;

--- a/docs/github-utils-guards.md
+++ b/docs/github-utils-guards.md
@@ -1,0 +1,60 @@
+# github-utils.sh Guard System
+
+`github-utils.sh` is auto-generated from `daylight.sh` by
+`extract-github-funcs.sh`. Manual edits to it will be overwritten.
+
+## How it stays in sync
+
+Three layers prevent out-of-sync or human-edited copies from reaching `main`.
+
+### 1. Auto-generation on push
+
+**File:** `.github/workflows/generate-github-utils.yml`
+
+Whenever `daylight.sh` is pushed to `main`, this workflow runs
+`./extract-github-funcs.sh > github-utils.sh` and auto-commits the result
+via [`stefanzweifel/git-auto-commit-action`][git-auto-commit]. The
+workflow only triggers on `daylight.sh` changes (`paths:` filter), so the
+auto-commit doesn't re-trigger itself. Humans should never need to touch
+this file.
+
+### 2. PR validation
+
+**File:** `.github/workflows/validate-github-utils.yml`
+
+On any PR that touches `github-utils.sh` or `daylight.sh`, this workflow
+regenerates `github-utils.sh` from `daylight.sh` and diffs it against the
+committed version using plain `diff`. If they differ, the check fails,
+blocking the merge. This enforces that `github-utils.sh` is always the
+exact output of `extract-github-funcs.sh`.
+
+### 3. Code ownership
+
+**File:** `.github/CODEOWNERS`
+
+[CODEOWNERS][codeowners-docs] is a GitHub feature that lets you assign
+review responsibilities to specific files or patterns. The entry:
+
+```
+github-utils.sh    @github-actions
+```
+
+means any PR that modifies `github-utils.sh` automatically requests
+review from the `@github-actions` bot account. With branch protection
+configured to **require code owner approval**, a human-edited PR cannot
+merge without the bot's sign-off — which it will never give, since the
+bot only auto-commits via the push workflow above.
+
+## Recovery
+
+If `github-utils.sh` is ever out of sync, run locally:
+
+```bash
+./extract-github-funcs.sh > github-utils.sh
+```
+
+Or simply push a change to `daylight.sh` — the push-triggered workflow
+will regenerate it.
+
+[git-auto-commit]: https://github.com/stefanzweifel/git-auto-commit-action
+[codeowners-docs]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/extract-github-funcs.sh
+++ b/extract-github-funcs.sh
@@ -1,0 +1,86 @@
+extract-func ()
+{
+    local script=$1
+    local func_name=$2
+
+    [[ -f "$script" ]] || { printf 'Error: script not found: %s\n' "$script" >&2; return 1; }
+    [[ -n "$func_name" ]] || { printf 'Error: function name is required\n' >&2; return 1; }
+
+    local preamble=""
+    local in_func=false
+    local found=false
+    local line
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if ! $in_func; then
+            if [[ "$line" == "$func_name ()" ]]; then
+                printf '%s' "$preamble"
+                printf '%s\n' "$line"
+                in_func=true
+                found=true
+            elif [[ "$line" == '#'* ]]; then
+                preamble+="$line"$'\n'
+            elif [[ -z "$line" ]]; then
+                preamble=""
+            else
+                preamble=""
+            fi
+        else
+            printf '%s\n' "$line"
+            if [[ "$line" == '}' ]]; then
+                printf '\n'
+                return 0
+            fi
+        fi
+    done < "$script"
+
+    if ! $found; then
+        printf 'Error: function "%s" not found in %s\n' "$func_name" "$script" >&2
+        return 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    daylight_script="$script_dir/daylight.sh"
+
+    [[ -f "$daylight_script" ]] || { printf 'Error: daylight.sh not found at %s\n' "$daylight_script" >&2; exit 1; }
+
+    printf '# github-utils.sh -- generated from daylight.sh on %s. Do not edit directly.\n' "$(date)"
+    printf '\n'
+
+    for func in \
+        github-app-get-client-id \
+        github-app-get-data \
+        github-app-get-id \
+        github-app-get-info \
+        github-create-flags \
+        github-create-url \
+        github-create-user-access-token \
+        github-curl \
+        github-curl-post \
+        github-detect-platform \
+        github-download-latest-release \
+        github-get-release-data \
+        github-get-release-name-list \
+        github-get-release-package-data \
+        github-get-release-package-info \
+        github-parse-args \
+        github-release-create-url-path \
+        github-release-download \
+        github-release-download-latest \
+        github-release-get-data \
+        github-release-get-latest-tag \
+        github-release-get-package-data \
+        github-release-get-package-info \
+        github-release-install \
+        github-release-install-latest \
+        github-release-list \
+        github-release-list-platforms \
+        github-release-select \
+        github-release-select-platform \
+        github-test-repo \
+        github-test-repo-with-auth; do
+        extract-func "$daylight_script" "$func"
+    done
+fi


### PR DESCRIPTION
Adds `github-detect-platform` to daylight.sh, creates `extract-github-funcs.sh` extraction tool, and adds three CI files:

- `.github/workflows/generate-github-utils.yml` — auto-generates `github-utils.sh` on push to `daylight.sh`
- `.github/workflows/validate-github-utils.yml` — validates `github-utils.sh` is in sync on PRs
- `.github/CODEOWNERS` — blocks manual edits to `github-utils.sh`