### PR TITLE
Migrate nightly releases to GHA workflows

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,22 @@
+name: Nightly release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate tag
+        id: tag
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: Generate github-utils.sh
+        run: ./extract-github-funcs.sh > github-utils.sh
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.DATE }}
+          target_commitish: main
+          files: github-utils.sh
+          body: "Nightly release — ${{ steps.tag.outputs.DATE }}"

--- a/daylight.sh
+++ b/daylight.sh
@@ -4085,6 +4085,56 @@ install-awscli ()
 
 #-------------------------------------------------------------------------------
 #
+# install-build-nightly-svc()
+#
+# Install a systemd indexed service for nightly releases of a repo.
+# Downloads template unit files from the daylight repo and writes a
+# repo-specific run.sh that calls trigger-nightly-release on dispatch.
+# Enables the timer and warns about the missing env file.
+#
+install-build-nightly-svc ()
+{
+    (( $# == 1 )) || { printf 'Usage: install-build-nightly-svc $repo\n' >&2; return 1; }
+    local repo=$1
+    local instance=${repo//\//-}
+    local base="https://raw.githubusercontent.com/daylight-public/daylight/main"
+    local svcDir=/opt/svc/nightly-release
+
+    mkdir -p "$svcDir/$instance/bin"
+    chown -R rayray:rayray "$svcDir"
+
+    curl -s --remote-name --output-dir /etc/systemd/system \
+        "$base/svc/nightly-release/nightly-release@.service"
+    curl -s --remote-name --output-dir /etc/systemd/system \
+        "$base/svc/nightly-release/nightly-release@.timer"
+
+    cat > "$svcDir/$instance/bin/run.sh" <<'RUNEOF'
+#!/usr/bin/env bash
+main ()
+{
+    local svcDir=/opt/svc/nightly-release
+    cd "$svcDir/INSTANCE/repo" || exit 1
+    git pull --ff-only origin main || exit 1
+    source ./sunbeam.sh 2>/dev/null || source ./daylight.sh 2>/dev/null || {
+        printf 'error: no script to source\n'; exit 1
+    }
+    trigger-nightly-release "REPO" || exit 1
+}
+main "$@"
+RUNEOF
+    sed -i "s/INSTANCE/$instance/g; s|REPO|$repo|g" "$svcDir/$instance/bin/run.sh"
+    chmod 755 "$svcDir/$instance/bin/run.sh"
+
+    systemctl enable "nightly-release@$instance.service"
+    systemctl enable "nightly-release@$instance.timer"
+    systemctl start "nightly-release@$instance.timer"
+
+    printf 'NOTE: Create %s/%s/env with GITHUB_PAT=... before timer fires\n' "$svcDir" "$instance"
+}
+
+
+#-------------------------------------------------------------------------------
+#
 # install-dylt ()
 #
 # download the latest dylt binary and install it in the specified folder.
@@ -5578,6 +5628,24 @@ setup-domain ()
 
 #-------------------------------------------------------------------------------
 #
+# sanitize-label()
+#
+# Sanitize a human-readable label for use in a git tag.
+# Spaces become dashes; non-alphanumeric, non-dot, non-underscore,
+# non-hyphen characters are stripped.
+#
+sanitize-label ()
+{
+    (( $# == 1 )) || { printf 'Usage: sanitize-label $label\n' >&2; return 1; }
+    local label=$1
+    label=${label// /-}
+    label=${label//[^a-zA-Z0-9._-]/}
+    printf '%s' "$label"
+}
+
+
+#-------------------------------------------------------------------------------
+#
 # source-daylight()
 #
 # Source the daylight.sh script
@@ -5863,6 +5931,26 @@ sync-run-service ()
 
 	unitName=$(sync-create-unit-name "$key" "$downloadPath") || return
 	systemctl start "$unitName" || return
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# trigger-nightly-release()
+#
+# Trigger a nightly-release GHA workflow for a given repo via workflow_dispatch.
+# Requires $GITHUB_PAT in the environment.
+#
+trigger-nightly-release ()
+{
+    (( $# == 1 )) || { printf 'Usage: trigger-nightly-release $owner/$repo\n' >&2; return 1; }
+    local repo=$1
+    local token=${GITHUB_PAT:?error: GITHUB_PAT not set}
+    curl --fail --silent --show-error -X POST \
+        "https://api.github.com/repos/$repo/actions/workflows/nightly-release.yml/dispatches" \
+        -H "Authorization: Bearer $token" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -d '{"ref": "main"}' || return
 }
 
 
@@ -6307,6 +6395,7 @@ main ()
             init-rpi)                                 init-rpi "$@";;
             install-app)                              install-app "$@";;
             install-awscli)                           install-awscli "$@";;
+            install-build-nightly-svc)                install-build-nightly-svc "$@";;
             install-dylt)                             install-dylt "$@";;
             install-etcd)                             install-etcd "$@";;
             install-flask-app)                        install-flask-app "$@";;
@@ -6353,6 +6442,7 @@ main ()
             replace-nginx-conf)                       replace-nginx-conf "$@";;
             run-conf-script)                          run-conf-script "$@";;
             run-service)                              run-service "$@";;
+            sanitize-label)                           sanitize-label "$@";;
             setup-domain)                             setup-domain "$@";;
             source-daylight)                          source-daylight "$@";;
             source-service-environment-file)          source-service-environment-file "$@";;
@@ -6364,6 +6454,7 @@ main ()
             sync-follow-service)                      sync-follow-service "$@";;
             sync-remove-service)                      sync-remove-service "$@";;
             sync-run-service)                         sync-run-service "$@";;
+            trigger-nightly-release)                  trigger-nightly-release "$@";;
             sys-start)                                sys-start "$@";;
             uninstall-etcd)                           uninstall-etcd "$@";;
             untar-to-temp-folder)                     untar-to-temp-folder "$@";;

--- a/svc/nightly-release/nightly-release@.service
+++ b/svc/nightly-release/nightly-release@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Nightly release for %i
+
+[Service]
+Type=oneshot
+User=rayray
+WorkingDirectory=/opt/svc/nightly-release/%i
+EnvironmentFile=/opt/svc/nightly-release/%i/env
+ExecStart=/opt/svc/nightly-release/%i/bin/run.sh

--- a/svc/nightly-release/nightly-release@.timer
+++ b/svc/nightly-release/nightly-release@.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer for nightly release of %i
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+Unit=nightly-release@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Move nightly release logic from local bash scripts into GitHub Actions workflows, triggered by `workflow_dispatch` via a timer-driven `curl` call. Systemd units use an indexed service template with `EnvironmentFile` for token management. Templates live in the daylight repo.

### New files

| File | Purpose |
|------|---------|
| `svc/nightly-release/nightly-release@.service` | Indexed systemd unit template |
| `svc/nightly-release/nightly-release@.timer` | Daily 03:00 timer template |
| `.github/workflows/nightly-release.yml` | On `workflow_dispatch`, creates date tag + releases `github-utils.sh` |

### New functions in `daylight.sh`

- `sanitize-label()` — sanitize human-readable labels for git tags
- `trigger-nightly-release()` — POST workflow_dispatch to GHA
- `install-build-nightly-svc()` — install indexed service for a repo

## Tag format

First daily: `2026-06-18`
Second same day: `2026-06-18-093022` (timestamp fallback)

## Admin setup required

1. Create `NIGHTLY_RELEASE_PAT` secret (repo → Settings → Secrets → Actions, `contents:write`)
2. Create `/opt/svc/nightly-release/<instance>/env` with `GITHUB_PAT=...`
3. Clone repos and run `install-build-nightly-svc`