### PR TITLE
Fix backfill workflow: missing directory and error masking

### DIFF
--- a/.github/workflows/backfill-checksums.yml
+++ b/.github/workflows/backfill-checksums.yml
@@ -12,6 +12,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.NIGHTLY_RELEASE_PAT }}
         run: |
+          set -o pipefail
+          mkdir -p /tmp/backfill
+
           # List all nightly releases (tagName only, up to 1000)
           gh release list --repo ${{ github.repository }} --limit 1000 \
             --json tagName,assets \
@@ -34,7 +37,10 @@ jobs:
             }
 
             # Checksum the archive and upload
-            cd /tmp/backfill
+            cd /tmp/backfill || {
+              echo "  failed to cd to /tmp/backfill, skip"
+              continue
+            }
             sha256sum -- *.tar.gz > SHA256SUMS
             gh release upload "$tag" SHA256SUMS --repo ${{ github.repository }} \
               --clobber


### PR DESCRIPTION
One-off backfill workflow had two bugs:

1. **Missing directory** — `gh release download --dir /tmp/backfill` fails because the directory never gets created. Every iteration hits `|| { continue; }`, so all releases are silently skipped and no checksums are generated.

2. **Pipeline error masking** — `gh release list | while ...` runs the while in a pipeline. Without `set -o pipefail`, the exit code is the while loop`'`s exit (always 0), not the `gh release list` exit. So even if the list command fails, the step reports success.

**Fixes:**
- Added `mkdir -p /tmp/backfill` before the loop
- Added `cd` error check with `|| continue`
- Added `set -o pipefail` at top of run block

Closes #66