### PR TITLE
download-daylight-batch: branch/release modes with flag parser

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           tar -czf "${{ steps.tag.outputs.ASSET_BASE }}.tar.gz" daylight.sh
           zip "${{ steps.tag.outputs.ASSET_BASE }}.zip" daylight.sh
+          sha256sum "${{ steps.tag.outputs.ASSET_BASE }}.tar.gz" "${{ steps.tag.outputs.ASSET_BASE }}.zip" > SHA256SUMS
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -52,6 +53,7 @@ jobs:
           files: |
             ${{ steps.tag.outputs.ASSET_BASE }}.tar.gz
             ${{ steps.tag.outputs.ASSET_BASE }}.zip
+            SHA256SUMS
           body: "Daylight release — ${{ steps.tag.outputs.TAG }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,25 @@ When new functions are added to daylight.sh they should be added to the main cas
 
 ### pushing code changes
 
-All code changes will be done on new branches, with short names -- 2 or 3 words or terms separated by hyphens. Ask me to approve branch names. After committing and pushing a branch, create a PR for the change, where the body of the PR contains information similar or identical to the plan markdown. Create an issue and link it to the PR. Ask what the issue should be labelled - Bug, Task, or Feature. 
+All code changes will be done on new branches, with short names -- 2 or 3 words or terms separated by hyphens. Ask me to approve branch names. After committing and pushing a branch, create a PR for the change, where the body of the PR contains information similar or identical to the plan markdown. Create an issue and link it to the PR. Ask what the issue should be labelled - Bug, Task, or Feature.
+
+### download-daylight flags
+
+`download-daylight` uses a custom flag parser (not `github-parse-args`) for branch/release selection.
+
+| Flag | Value | Behavior |
+|---|---|---|
+| (none) | — | Branch mode, defaults to `main` |
+| `--branch` | (no value) | Branch mode, defaults to `main` |
+| `--branch <name>` | branch name | Branch mode, specific branch |
+| `--release` | (no value) | Release mode, latest release |
+| `--release <tag>` | tag name | Release mode, specific tag |
+| `--release --latest` | — | Same as `--release` with no value |
+| `--latest` alone | — | Error: requires `--release` |
+| `--branch` + `--release` | — | Error: incompatible |
+
+Rules:
+- Flags are parsed in order. The optional value after `--branch` or `--release` is consumed only if it doesn't start with `--`.
+- `--latest` must follow `--release` (either immediately or as a later flag).
+- The destination folder is the first positional argument after all flags.
+- Exactly one of branch mode or release mode must be active. 

--- a/daylight.sh
+++ b/daylight.sh
@@ -823,21 +823,158 @@ download-app ()
 
 #-------------------------------------------------------------------------------
 #
+# download-daylight-batch()
+#
+# Download daylight.sh from a GitHub branch or release
+#
+download-daylight-batch ()
+{
+    # shellcheck disable=SC2016
+    local branch="" release="" latest=0
+    local -a pass=()
+    local dstFolder=""
+
+    local args=("$@")
+    local i=0
+    while (( i < $# )); do
+        case "${args[i]}" in
+            --branch)
+                if [[ -n "$release" ]]; then
+                    printf 'Error: --branch and --release are incompatible\n' >&2
+                    return 1
+                fi
+                if (( i+1 < $# )) && [[ "${args[i+1]}" != --* ]]; then
+                    branch=${args[i+1]}
+                    (( i++ ))
+                else
+                    branch=main
+                fi
+                ;;
+            --release)
+                if [[ -n "$branch" ]]; then
+                    printf 'Error: --branch and --release are incompatible\n' >&2
+                    return 1
+                fi
+                if (( i+1 < $# )) && [[ "${args[i+1]}" != --* ]]; then
+                    release=${args[i+1]}
+                    (( i++ ))
+                else
+                    release=latest
+                fi
+                ;;
+            --latest)
+                latest=1
+                ;;
+            --token)
+                if (( i+1 < $# )); then
+                    pass+=("${args[i]}" "${args[i+1]}")
+                    (( i++ ))
+                else
+                    printf 'Error: --token requires a value\n' >&2
+                    return 1
+                fi
+                ;;
+            --)
+                (( i++ ))
+                break
+                ;;
+            --*)
+                printf 'Unknown flag: %s\n' "${args[i]}" >&2
+                return 1
+                ;;
+            *)
+                if [[ -z "$dstFolder" ]]; then
+                    dstFolder=${args[i]}
+                else
+                    printf 'Unexpected argument: %s\n' "${args[i]}" >&2
+                    return 1
+                fi
+                ;;
+        esac
+        (( i++ ))
+    done
+
+    while (( i < $# )); do
+        if [[ -z "$dstFolder" ]]; then
+            dstFolder=${args[i]}
+        else
+            pass+=("${args[i]}")
+        fi
+        (( i++ ))
+    done
+
+    [[ -n "$dstFolder" ]] || { printf 'Usage: download-daylight-batch [--branch [<name>]] [--release [<tag>]] [--latest] [--] <dstFolder>\n' >&2; return 1; }
+    [[ -d "$dstFolder" ]] || { printf 'Non-existent folder: %s\n' "$dstFolder" >&2; return 1; }
+
+    if (( latest )) && [[ -z "$release" ]]; then
+        printf 'Error: --latest requires --release\n' >&2
+        return 1
+    fi
+    if [[ -z "$branch" && -z "$release" ]]; then
+        branch=main
+    fi
+
+    local org=daylight-public
+    local repo=daylight
+
+    if [[ -n "$release" ]]; then
+        local tag json assetName tmpDir releasePath checksumFile
+        local checksumName=SHA256SUMS
+
+        if [[ "$release" == "latest" ]]; then
+            tag=$(github-release-get-latest-tag "${pass[@]}" "$org" "$repo") || return
+        else
+            tag=$release
+        fi
+
+        tmpDir=$(create-temp-folder) || return
+
+        json=$(github-release-get-data --version "$tag" "${pass[@]}" "$org" "$repo") || return
+        assetName=$(printf '%s' "$json" | jq -r '.assets[] | select(.name | endswith(".tar.gz")) | .name' | head -1) || {
+            printf 'No tar.gz asset found in release %s\n' "$tag" >&2
+            rm -rf "$tmpDir"
+            return 1
+        }
+
+        releasePath=$(github-release-download --version "$tag" "${pass[@]}" "$org" "$repo" "$assetName" "$tmpDir") || {
+            rm -rf "$tmpDir"
+            return 1
+        }
+
+        checksumFile=$(github-release-download --version "$tag" "${pass[@]}" "$org" "$repo" "$checksumName" "$tmpDir") || {
+            printf 'SHA256SUMS not found in release %s — cannot verify integrity\n' "$tag" >&2
+            rm -rf "$tmpDir"
+            return 1
+        }
+
+        if ! (cd "$tmpDir" && grep -F "$assetName" "$checksumName" | sha256sum -c -); then
+            printf 'Checksum verification failed for %s\n' "$assetName" >&2
+            rm -rf "$tmpDir"
+            return 1
+        fi
+
+        tar -xzf "$releasePath" -C "$dstFolder" daylight.sh || {
+            rm -rf "$tmpDir"
+            return 1
+        }
+
+        rm -rf "$tmpDir"
+    else
+        local url="https://raw.githubusercontent.com/$org/$repo/$branch/daylight.sh"
+        curl --location --silent --fail --output-dir "$dstFolder" --remote-name "$url" || return
+    fi
+}
+
+
+#-------------------------------------------------------------------------------
+#
 # download-daylight()
 #
-# Download daylight.sh from a GitHub branch
+# Download daylight.sh with optional interactive prompts
 #
 download-daylight ()
 {
-    # shellcheck disable=SC2016
-    (( $# == 2 )) || { printf 'Usage: download-daylight $branch $dstFolder\n' >&2; return 1; }
-    local branch=$1
-    local dstFolder=$2
-    [[ -d "$dstFolder" ]] || { echo "Non-existent folder: $dstFolder" >&2; return 1; }
-    local org=daylight-public
-    local repo=daylight
-    url="https://raw.githubusercontent.com/$org/$repo/$branch/daylight.sh"
-    curl --location --silent --output-dir "$dstFolder" --remote-name "$url"
+    download-daylight-batch "$@" || return
 }
 
 
@@ -6375,6 +6512,7 @@ main ()
             delete-lxd-instance)                      delete-lxd-instance "$@";;
             download-app)                             download-app "$@";;
             download-daylight)                        download-daylight "$@";;
+            download-daylight-batch)                  download-daylight-batch "$@";;
             download-dist)                            download-dist "$@";;
             download-dylt)                            download-dylt "$@";;
             download-flask-app)                       download-flask-app "$@";;


### PR DESCRIPTION
Implement download-daylight-batch with custom flag parser for branch/release selection.

## Changes

**daylight.sh:**
- Rename `download-daylight` → `download-daylight-batch`
- Custom flag parser: `--branch [<name>]`, `--release [<tag>]`, `--latest`, `--token`
- Branch mode: raw URL download from any branch
- Release mode: API-discover tar.gz asset → download → grep SHA256SUMS | sha256sum -c - → extract
- New `download-daylight` wrapper (interactive prompt deferred to follow-up)
- main() case: added `download-daylight-batch` entry

**nightly-release.yml:**
- Generate SHA256SUMS covering both .tar.gz and .zip
- Upload SHA256SUMS as a release asset

Closes #70