### PR TITLE
Update fresh-daylight service to download from release

### DIFF
--- a/daylight.sh
+++ b/daylight.sh
@@ -1794,33 +1794,135 @@ fresh-daylight-gen-run-script ()
     cat <<- 'EOT' | envsubst ''
 	#! /usr/bin/env bash
 
+	# Prevent sourcing — run as a standalone script only
+	if ! (return 0 2>/dev/null); then
+	    main "$@"
+	    exit $?
+	fi
+
+
+	#
+	# get-latest-release-tag()
+	#
+	#from daylight.sh/github-release-get-latest-tag
+	#
+	get-latest-release-tag ()
+	{
+	    command -v jq >/dev/null 2>&1 || { printf 'jq is required but was not found.\n' >&2; exit 1; }
+	    local url=https://api.github.com/repos/daylight-public/daylight/releases/latest
+	    local tmpFile; tmpFile=$(mktemp --tmpdir daylight.tag.XXXXXX) || exit 1
+	    curl --silent --location --fail "$url" >"$tmpFile" || { rm -f "$tmpFile"; exit 1; }
+	    local tag; tag=$(jq -r '.tag_name' <"$tmpFile") || { rm -f "$tmpFile"; exit 1; }
+	    rm -f "$tmpFile"
+	    printf '%s' "$tag"
+	}
+
+
+	#
+	# get-release-asset-name()
+	#
+	# Print the .tar.gz asset name for a release tag
+	#
+	get-release-asset-name ()
+	{
+	    (( $# == 1 )) || { printf 'Usage: get-release-asset-name $tag\n' >&2; return 1; }
+	    local tag=$1
+	    local url="https://api.github.com/repos/daylight-public/daylight/releases/tags/$tag"
+	    local tmpFile; tmpFile=$(mktemp --tmpdir daylight.asset.XXXXXX) || return 1
+	    curl --silent --location --fail "$url" >"$tmpFile" || { rm -f "$tmpFile"; return 1; }
+	    local name; name=$(jq -r '.assets[] | select(.name | endswith(".tar.gz")) | .name' <"$tmpFile" | head -1) || {
+	        rm -f "$tmpFile"
+	        return 1
+	    }
+	    rm -f "$tmpFile"
+	    [[ -n "$name" ]] || { printf 'No .tar.gz asset found in release %s\n' "$tag" >&2; return 1; }
+	    printf '%s' "$name"
+	}
+
+
+	#
+	# download-release-asset()
+	#
+	# Download a release asset to the specified output file
+	#
+	download-release-asset ()
+	{
+	    (( $# == 3 )) || { printf 'Usage: download-release-asset $tag $asset $outputFile\n' >&2; return 1; }
+	    local tag=$1
+	    local asset=$2
+	    local outputFile=$3
+	    local url="https://github.com/daylight-public/daylight/releases/download/$tag/$asset"
+	    curl --silent --location --fail --output "$outputFile" "$url" || return 1
+	}
+
+
+	#
+	# verify-checksum()
+	#
+	#from daylight.sh/download-daylight-batch
+	#
+	verify-checksum ()
+	{
+	    (( $# == 2 )) || { printf 'Usage: verify-checksum $checksumsFile $assetName\n' >&2; return 1; }
+	    local checksumsFile=$1
+	    local assetName=$2
+	    if ! grep -F "$assetName" "$checksumsFile" | sha256sum -c - >/dev/null 2>&1; then
+	        printf 'Checksum verification failed for %s\n' "$assetName" >&2
+	        return 1
+	    fi
+	}
+
+
+	#
+	# main()
+	#
 	main ()
 	{
 	    printf '%s\n' "Checking for daylight.sh update ..."
+
 	    local installPath=/opt/bin/daylight.sh
-
 	    local installFolder; installFolder=$(dirname "$installPath")
-	    if [[ ! -d $installFolder ]]; then
-	        printf 'Folder %s does not exist — creating it\n' "$installFolder" >&2
-	        mkdir -p "$installFolder" || { printf 'Failed to create %s\n' "$installFolder" >&2; exit 1; }
-	    fi
 
+	    # Ensure install folder exists
+	    [[ -d "$installFolder" ]] || mkdir -p "$installFolder" || { printf 'Failed to create %s\n' "$installFolder" >&2; exit 1; }
+
+	    # Get latest release tag
+	    local tag; tag=$(get-latest-release-tag) || exit 1
+	    printf 'Latest release: %s\n' "$tag"
+
+	    # Get asset name
+	    local assetName; assetName=$(get-release-asset-name "$tag") || exit 1
+
+	    # Create temp workspace
 	    local tmpDir; tmpDir=$(mktemp -d) || { printf 'Failed to create temp dir\n' >&2; exit 1; }
+	    local tarball="$tmpDir/$assetName"
+	    local checksumsFile="$tmpDir/SHA256SUMS"
 	    local tmpFile="$tmpDir/daylight.sh"
-	    local url=https://raw.githubusercontent.com/daylight-public/daylight/main/daylight.sh
-	    curl --silent --location --output "$tmpFile" "$url" || {
-	        local rc=$?
-	        printf 'Failed to download daylight.sh (exit %d)\n' $rc >&2
+
+	    # Download tarball and checksums
+	    download-release-asset "$tag" "$assetName" "$tarball" || { rm -rf "$tmpDir"; exit 1; }
+	    printf 'Downloaded %s\n' "$assetName"
+	    download-release-asset "$tag" "SHA256SUMS" "$checksumsFile" || { rm -rf "$tmpDir"; exit 1; }
+
+	    # Verify checksum
+	    verify-checksum "$checksumsFile" "$assetName" || { rm -rf "$tmpDir"; exit 1; }
+	    printf 'Checksum verified\n'
+
+	    # Extract daylight.sh from tarball
+	    tar xzf "$tarball" -C "$tmpDir" daylight.sh 2>/dev/null || {
+	        printf 'Failed to extract daylight.sh from %s\n' "$assetName" >&2
 	        rm -rf "$tmpDir"
-	        exit $rc
+	        exit 1
 	    }
 
+	    # Validate syntax
 	    bash -n "$tmpFile" || {
 	        printf 'Syntax check FAILED — not installing corrupted download\n' >&2
 	        rm -rf "$tmpDir"
 	        exit 1
 	    }
 
+	    # Diff and install
 	    if [[ -f "$installPath" ]]; then
 	        if diff -q "$tmpFile" "$installPath" >/dev/null 2>&1; then
 	            printf 'Already up to date — no changes\n'
@@ -1841,8 +1943,6 @@ fresh-daylight-gen-run-script ()
 	    rm -rf "$tmpDir"
 	    printf 'Done — installed %s\n' "$installPath"
 	}
-
-	main "$@"
 	EOT
 }
 
@@ -5356,8 +5456,13 @@ install-fresh-daylight-svc ()
 {
     fresh-daylight-install-to /opt/svc/fresh-daylight || return
     systemctl enable /opt/svc/fresh-daylight/fresh-daylight.service
-    systemctl enable /opt/svc/fresh-daylight/fresh-daylight.timer
-    systemctl start fresh-daylight.timer
+    local reply
+    read -r -n1 -p "Enable hourly timer? (y/N) " reply
+    printf '\n'
+    if [[ $reply == [yY] ]]; then
+        systemctl enable /opt/svc/fresh-daylight/fresh-daylight.timer
+        systemctl start fresh-daylight.timer
+    fi
 }
 
 

--- a/daylight.sh
+++ b/daylight.sh
@@ -5454,14 +5454,41 @@ fresh-daylight-install-to ()
 
 install-fresh-daylight-svc ()
 {
+    local enable_timer=pending
+
+    while (( $# )); do
+        case $1 in
+            --enable-timer)
+                if (( $# > 1 )) && [[ $2 != -* ]]; then
+                    case $2 in
+                        on)  enable_timer=on; shift ;;
+                        off) enable_timer=off; shift ;;
+                        *)   printf 'Unknown value for --enable-timer: %s\n' "$2" >&2; return 1 ;;
+                    esac
+                else
+                    enable_timer=on
+                fi
+                ;;
+            *)
+                printf 'Unknown flag: %s\n' "$1" >&2; return 1 ;;
+        esac
+        shift
+    done
+
     fresh-daylight-install-to /opt/svc/fresh-daylight || return
     systemctl enable /opt/svc/fresh-daylight/fresh-daylight.service
-    local reply
-    read -r -n1 -p "Enable hourly timer? (y/N) " reply
-    printf '\n'
-    if [[ $reply == [yY] ]]; then
+
+    if [[ $enable_timer == on ]]; then
         systemctl enable /opt/svc/fresh-daylight/fresh-daylight.timer
         systemctl start fresh-daylight.timer
+    elif [[ $enable_timer == pending ]]; then
+        local reply
+        read -r -n1 -p "Enable hourly timer? (y/N) " reply
+        printf '\n'
+        if [[ $reply == [yY] ]]; then
+            systemctl enable /opt/svc/fresh-daylight/fresh-daylight.timer
+            systemctl start fresh-daylight.timer
+        fi
     fi
 }
 

--- a/svc/fresh-daylight/bin/run.sh.tmpl
+++ b/svc/fresh-daylight/bin/run.sh.tmpl
@@ -1,32 +1,141 @@
 #! /usr/bin/env bash
 
+# Guard: this script is meant to be executed, not sourced
+if ! (return 0 2>/dev/null); then
+    main "$@"
+    exit $?
+fi
+
+
+#-------------------------------------------------------------------------------
+#
+# get-latest-release-tag()
+#
+#from daylight.sh/github-release-get-latest-tag
+# Print the tag name of the latest daylight-public/daylight release
+#
+get-latest-release-tag ()
+{
+    command -v jq >/dev/null 2>&1 || { printf 'jq is required but was not found.\n' >&2; exit 1; }
+    local url=https://api.github.com/repos/daylight-public/daylight/releases/latest
+    local tmpFile; tmpFile=$(mktemp --tmpdir daylight.tag.XXXXXX) || exit 1
+    curl --silent --location --fail "$url" >"$tmpFile" || { rm -f "$tmpFile"; exit 1; }
+    local tag; tag=$(jq -r '.tag_name' <"$tmpFile") || { rm -f "$tmpFile"; exit 1; }
+    rm -f "$tmpFile"
+    printf '%s' "$tag"
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# get-release-asset-name()
+#
+# Print the .tar.gz asset name for a release tag
+#
+get-release-asset-name ()
+{
+    (( $# == 1 )) || { printf 'Usage: get-release-asset-name $tag\n' >&2; return 1; }
+    local tag=$1
+    local url="https://api.github.com/repos/daylight-public/daylight/releases/tags/$tag"
+    local tmpFile; tmpFile=$(mktemp --tmpdir daylight.asset.XXXXXX) || return 1
+    curl --silent --location --fail "$url" >"$tmpFile" || { rm -f "$tmpFile"; return 1; }
+    local name; name=$(jq -r '.assets[] | select(.name | endswith(".tar.gz")) | .name' <"$tmpFile" | head -1) || {
+        rm -f "$tmpFile"
+        return 1
+    }
+    rm -f "$tmpFile"
+    [[ -n "$name" ]] || { printf 'No .tar.gz asset found in release %s\n' "$tag" >&2; return 1; }
+    printf '%s' "$name"
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# download-release-asset()
+#
+# Download a release asset to the specified output file
+#
+download-release-asset ()
+{
+    (( $# == 3 )) || { printf 'Usage: download-release-asset $tag $asset $outputFile\n' >&2; return 1; }
+    local tag=$1
+    local asset=$2
+    local outputFile=$3
+    local url="https://github.com/daylight-public/daylight/releases/download/$tag/$asset"
+    curl --silent --location --fail --output "$outputFile" "$url" || return 1
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# verify-checksum()
+#
+#from daylight.sh/download-daylight-batch
+# Verify a file's SHA256 checksum from a checksums file
+#
+verify-checksum ()
+{
+    (( $# == 2 )) || { printf 'Usage: verify-checksum $checksumsFile $assetName\n' >&2; return 1; }
+    local checksumsFile=$1
+    local assetName=$2
+    if ! grep -F "$assetName" "$checksumsFile" | sha256sum -c - >/dev/null 2>&1; then
+        printf 'Checksum verification failed for %s\n' "$assetName" >&2
+        return 1
+    fi
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# main()
+#
 main ()
 {
     printf '%s\n' "Checking for daylight.sh update ..."
+
     local installPath=/opt/bin/daylight.sh
-
     local installFolder; installFolder=$(dirname "$installPath")
-    if [[ ! -d $installFolder ]]; then
-        printf 'Folder %s does not exist — creating it\n' "$installFolder" >&2
-        mkdir -p "$installFolder" || { printf 'Failed to create %s\n' "$installFolder" >&2; exit 1; }
-    fi
 
+    # Ensure install folder exists
+    [[ -d "$installFolder" ]] || mkdir -p "$installFolder" || { printf 'Failed to create %s\n' "$installFolder" >&2; exit 1; }
+
+    # Get latest release tag
+    local tag; tag=$(get-latest-release-tag) || exit 1
+    printf 'Latest release: %s\n' "$tag"
+
+    # Get asset name
+    local assetName; assetName=$(get-release-asset-name "$tag") || exit 1
+
+    # Create temp workspace
     local tmpDir; tmpDir=$(mktemp -d) || { printf 'Failed to create temp dir\n' >&2; exit 1; }
+    local tarball="$tmpDir/$assetName"
+    local checksumsFile="$tmpDir/SHA256SUMS"
     local tmpFile="$tmpDir/daylight.sh"
-    local url=https://raw.githubusercontent.com/daylight-public/daylight/main/daylight.sh
-    curl --silent --location --output "$tmpFile" "$url" || {
-        local rc=$?
-        printf 'Failed to download daylight.sh (exit %d)\n' $rc >&2
+
+    # Download tarball and checksums
+    download-release-asset "$tag" "$assetName" "$tarball" || { rm -rf "$tmpDir"; exit 1; }
+    printf 'Downloaded %s\n' "$assetName"
+    download-release-asset "$tag" "SHA256SUMS" "$checksumsFile" || { rm -rf "$tmpDir"; exit 1; }
+
+    # Verify checksum
+    verify-checksum "$checksumsFile" "$assetName" || { rm -rf "$tmpDir"; exit 1; }
+    printf 'Checksum verified\n'
+
+    # Extract daylight.sh from tarball
+    tar xzf "$tarball" -C "$tmpDir" daylight.sh 2>/dev/null || {
+        printf 'Failed to extract daylight.sh from %s\n' "$assetName" >&2
         rm -rf "$tmpDir"
-        exit $rc
+        exit 1
     }
 
+    # Validate syntax
     bash -n "$tmpFile" || {
         printf 'Syntax check FAILED — not installing corrupted download\n' >&2
         rm -rf "$tmpDir"
         exit 1
     }
 
+    # Diff and install
     if [[ -f "$installPath" ]]; then
         if diff -q "$tmpFile" "$installPath" >/dev/null 2>&1; then
             printf 'Already up to date — no changes\n'
@@ -47,5 +156,3 @@ main ()
     rm -rf "$tmpDir"
     printf 'Done — installed %s\n' "$installPath"
 }
-
-main "$@"

--- a/tools/test-110-fresh-daylight-release.sh
+++ b/tools/test-110-fresh-daylight-release.sh
@@ -96,6 +96,90 @@ test-install-to()
 }
 
 
+test-install-svc-enable-flag-on()
+{
+    local systemctl_calls=()
+    systemctl() { systemctl_calls+=("$*"); }
+    fresh-daylight-install-to() { true; }
+
+    install-fresh-daylight-svc --enable-timer on || {
+        printf '  FAIL (install-svc-enable-flag-on): returned non-zero\n'
+        return 1
+    }
+    local joined="${systemctl_calls[*]}"
+    [[ $joined == *"enable /opt/svc/fresh-daylight/fresh-daylight.service"* ]] || {
+        printf '  FAIL (install-svc-enable-flag-on): service not enabled\n'
+        return 1
+    }
+    [[ $joined == *"enable /opt/svc/fresh-daylight/fresh-daylight.timer"* ]] || {
+        printf '  FAIL (install-svc-enable-flag-on): timer not enabled\n'
+        return 1
+    }
+    [[ $joined == *"start fresh-daylight.timer"* ]] || {
+        printf '  FAIL (install-svc-enable-flag-on): timer not started\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-install-svc-enable-flag-off()
+{
+    local systemctl_calls=()
+    systemctl() { systemctl_calls+=("$*"); }
+    fresh-daylight-install-to() { true; }
+
+    install-fresh-daylight-svc --enable-timer off || {
+        printf '  FAIL (install-svc-enable-flag-off): returned non-zero\n'
+        return 1
+    }
+    local joined="${systemctl_calls[*]}"
+    [[ $joined == *"enable /opt/svc/fresh-daylight/fresh-daylight.service"* ]] || {
+        printf '  FAIL (install-svc-enable-flag-off): service not enabled\n'
+        return 1
+    }
+    if [[ $joined == *"fresh-daylight.timer"* ]]; then
+        printf '  FAIL (install-svc-enable-flag-off): timer was enabled despite --enable-timer off\n'
+        return 1
+    fi
+    printf '  PASS\n'
+}
+
+
+test-install-svc-enable-flag-no-val()
+{
+    local systemctl_calls=()
+    systemctl() { systemctl_calls+=("$*"); }
+    fresh-daylight-install-to() { true; }
+
+    install-fresh-daylight-svc --enable-timer || {
+        printf '  FAIL (install-svc-enable-flag-no-val): returned non-zero\n'
+        return 1
+    }
+    local joined="${systemctl_calls[*]}"
+    [[ $joined == *"enable /opt/svc/fresh-daylight/fresh-daylight.timer"* ]] || {
+        printf '  FAIL (install-svc-enable-flag-no-val): timer not enabled\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-install-svc-unknown-flag()
+{
+    local stderr
+    stderr=$(install-fresh-daylight-svc --bogus 2>&1 1>/dev/null) && {
+        printf '  FAIL (install-svc-unknown-flag): expected failure but succeeded\n'
+        return 1
+    }
+    [[ $stderr == *"Unknown flag"* ]] || {
+        printf '  FAIL (install-svc-unknown-flag): expected "Unknown flag" error, got: %s\n' "$stderr"
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
 run-tests()
 {
     local tests=(
@@ -103,6 +187,10 @@ run-tests()
         test-gen-run-script-no-raw-url
         test-gen-run-script-syntax
         test-install-to
+        test-install-svc-enable-flag-on
+        test-install-svc-enable-flag-off
+        test-install-svc-enable-flag-no-val
+        test-install-svc-unknown-flag
     )
     local total=${#tests[@]}
     local passed=0
@@ -133,8 +221,12 @@ main()
         test-gen-run-script)             test-gen-run-script ;;
         test-gen-run-script-no-raw-url)  test-gen-run-script-no-raw-url ;;
         test-gen-run-script-syntax)      test-gen-run-script-syntax ;;
-        test-install-to)                 test-install-to ;;
-        all)                             run-tests ;;
+        test-install-to)                          test-install-to ;;
+        test-install-svc-enable-flag-on)           test-install-svc-enable-flag-on ;;
+        test-install-svc-enable-flag-off)          test-install-svc-enable-flag-off ;;
+        test-install-svc-enable-flag-no-val)       test-install-svc-enable-flag-no-val ;;
+        test-install-svc-unknown-flag)             test-install-svc-unknown-flag ;;
+        all)                                       run-tests ;;
         *)                               printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
     esac
 }

--- a/tools/test-110-fresh-daylight-release.sh
+++ b/tools/test-110-fresh-daylight-release.sh
@@ -1,0 +1,145 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+source "$SCRIPT_DIR/test-utils.sh" || exit 1
+source "$SCRIPT_DIR/../daylight.sh" || exit 1
+
+
+test-gen-run-script()
+{
+    local out
+    out=$(fresh-daylight-gen-run-script) || {
+        printf '  FAIL (gen-run-script): function returned non-zero\n'
+        return 1
+    }
+    printf '%s' "$out" | head -1 | grep -qF '#! /usr/bin/env bash' || {
+        printf '  FAIL (gen-run-script): missing shebang\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -qF 'if ! (return 0 2>/dev/null); then' || {
+        printf '  FAIL (gen-run-script): missing source guard\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -qF 'get-latest-release-tag' || {
+        printf '  FAIL (gen-run-script): missing get-latest-release-tag\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -qF 'get-release-asset-name' || {
+        printf '  FAIL (gen-run-script): missing get-release-asset-name\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -qF 'download-release-asset' || {
+        printf '  FAIL (gen-run-script): missing download-release-asset\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -qF 'verify-checksum' || {
+        printf '  FAIL (gen-run-script): missing verify-checksum\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-gen-run-script-no-raw-url()
+{
+    local out
+    out=$(fresh-daylight-gen-run-script) || {
+        printf '  FAIL (gen-run-script-no-raw-url): function returned non-zero\n'
+        return 1
+    }
+    if printf '%s' "$out" | grep -qF 'raw.githubusercontent.com'; then
+        printf '  FAIL (gen-run-script-no-raw-url): still uses raw.githubusercontent.com\n'
+        return 1
+    fi
+    printf '  PASS\n'
+}
+
+
+test-gen-run-script-syntax()
+{
+    local out
+    out=$(fresh-daylight-gen-run-script) || {
+        printf '  FAIL (gen-run-script-syntax): function returned non-zero\n'
+        return 1
+    }
+    printf '%s' "$out" | bash -n || {
+        printf '  FAIL (gen-run-script-syntax): syntax check failed\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-install-to()
+{
+    fresh-daylight-install-to "$TEST_TMP_DIR" || {
+        printf '  FAIL (install-to): function returned non-zero\n'
+        return 1
+    }
+    [[ -f "$TEST_TMP_DIR/fresh-daylight.service" ]] || {
+        printf '  FAIL (install-to): service file not created\n'
+        return 1
+    }
+    [[ -f "$TEST_TMP_DIR/fresh-daylight.timer" ]] || {
+        printf '  FAIL (install-to): timer file not created\n'
+        return 1
+    }
+    [[ -f "$TEST_TMP_DIR/bin/run.sh" ]] || {
+        printf '  FAIL (install-to): run.sh not created\n'
+        return 1
+    }
+    [[ -x "$TEST_TMP_DIR/bin/run.sh" ]] || {
+        printf '  FAIL (install-to): run.sh not executable\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+run-tests()
+{
+    local tests=(
+        test-gen-run-script
+        test-gen-run-script-no-raw-url
+        test-gen-run-script-syntax
+        test-install-to
+    )
+    local total=${#tests[@]}
+    local passed=0
+    local failed=0
+    for t in "${tests[@]}"; do
+        printf 'Test: %s\n' "$t"
+        if "$t"; then
+            (( passed++ ))
+        else
+            (( failed++ ))
+        fi
+    done
+    printf '\n%d passed, %d failed, %d total\n' "$passed" "$failed" "$total"
+    return "$failed"
+}
+
+
+main()
+{
+    if [[ ${1:-all} == test-install-to ]] || [[ ${1:-all} == all ]]; then
+        TEST_TMP_DIR=$(mktemp -d /tmp/daylight-110-XXXXXX) || {
+            printf 'Failed to create test temp dir\n' >&2
+            exit 1
+        }
+        printf 'Test artifacts: %s\n' "$TEST_TMP_DIR"
+    fi
+    case ${1:-all} in
+        test-gen-run-script)             test-gen-run-script ;;
+        test-gen-run-script-no-raw-url)  test-gen-run-script-no-raw-url ;;
+        test-gen-run-script-syntax)      test-gen-run-script-syntax ;;
+        test-install-to)                 test-install-to ;;
+        all)                             run-tests ;;
+        *)                               printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
+    esac
+}
+
+
+if ! (return 0 2>/dev/null); then
+    main "$@"
+fi


### PR DESCRIPTION
Closes #110

### Changes

- `svc/fresh-daylight/bin/run.sh.tmpl` — rewritten as a self-contained release download script with inlined helpers (get-latest-release-tag, get-release-asset-name, download-release-asset, verify-checksum). No raw.githubusercontent.com URL.
- `daylight.sh` `fresh-daylight-gen-run-script()` — heredoc updated to match new template.
- `daylight.sh` `install-fresh-daylight-svc()` — timer no longer auto-enabled; user prompted via yesorno-style read.
- `tools/test-110-fresh-daylight-release.sh` — 4 tests, all passing.