### PR TITLE
Create host-init() function for initializing daylight host VMs

### DIFF
--- a/daylight.sh
+++ b/daylight.sh
@@ -4719,6 +4719,30 @@ hello ()
 
 #-------------------------------------------------------------------------------
 #
+# host-init()
+#
+# Packages: install essential packages on a daylight host VM
+#
+host-init ()
+{
+    apt-get update -y
+    apt-get install -y \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        incus \
+        jq \
+        lsb-release \
+        nginx \
+        software-properties-common \
+        ufw \
+        || return
+}
+
+
+#-------------------------------------------------------------------------------
+#
 # incus-api-call()
 #
 # Call the Incus API and return filtered JSON output
@@ -7674,6 +7698,7 @@ main ()
             go-service-uninstall)                     go-service-uninstall "$@";;
             go-upgrade)                               go-upgrade "$@";;
             hello)                                    hello "$@";;
+            host-init)                                host-init "$@";;
             incus-config-snapshots)                   incus-config-snapshots "$@";;
             incus-create-profiles)                    incus-create-profiles "$@";;
             incus-dump-id-map)                        incus-dump-id-map "$@";;

--- a/tools/test-112-host-init.sh
+++ b/tools/test-112-host-init.sh
@@ -1,0 +1,106 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+source "$SCRIPT_DIR/test-utils.sh" || exit 1
+source "$SCRIPT_DIR/../daylight.sh" || exit 1
+
+
+test-host-init-calls-apt-get-update()
+{
+    local apt_calls=()
+    apt-get() { apt_calls+=("$*"); }
+
+    host-init || {
+        printf '  FAIL (host-init-calls-apt-get-update): function returned non-zero\n'
+        return 1
+    }
+    local joined="${apt_calls[*]}"
+    [[ $joined == *"update"* ]] || {
+        printf '  FAIL (host-init-calls-apt-get-update): apt-get update not called\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-host-init-installs-nginx()
+{
+    local apt_calls=()
+    apt-get() { apt_calls+=("$*"); }
+
+    host-init || {
+        printf '  FAIL (host-init-installs-nginx): function returned non-zero\n'
+        return 1
+    }
+    local joined="${apt_calls[*]}"
+    [[ $joined == *"install"* && $joined == *"nginx"* ]] || {
+        printf '  FAIL (host-init-installs-nginx): nginx not in apt-get install\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-host-init-installs-baseline()
+{
+    local apt_calls=()
+    apt-get() { apt_calls+=("$*"); }
+    local required=(ca-certificates curl git gnupg incus jq lsb-release nginx software-properties-common ufw)
+
+    host-init || {
+        printf '  FAIL (host-init-installs-baseline): function returned non-zero\n'
+        return 1
+    }
+    local joined="${apt_calls[*]}"
+    local missing=()
+    for pkg in "${required[@]}"; do
+        if [[ $joined != *"$pkg"* ]]; then
+            missing+=("$pkg")
+        fi
+    done
+    if (( ${#missing[@]} > 0 )); then
+        printf '  FAIL (host-init-installs-baseline): missing packages: %s\n' "${missing[*]}"
+        return 1
+    fi
+    printf '  PASS\n'
+}
+
+
+run-tests()
+{
+    local tests=(
+        test-host-init-calls-apt-get-update
+        test-host-init-installs-nginx
+        test-host-init-installs-baseline
+    )
+    local total=${#tests[@]}
+    local passed=0
+    local failed=0
+    for t in "${tests[@]}"; do
+        printf 'Test: %s\n' "$t"
+        if "$t"; then
+            (( passed++ ))
+        else
+            (( failed++ ))
+        fi
+    done
+    printf '\n%d passed, %d failed, %d total\n' "$passed" "$failed" "$total"
+    return "$failed"
+}
+
+
+main()
+{
+    case ${1:-all} in
+        test-host-init-calls-apt-get-update)   test-host-init-calls-apt-get-update ;;
+        test-host-init-installs-nginx)         test-host-init-installs-nginx ;;
+        test-host-init-installs-baseline)      test-host-init-installs-baseline ;;
+        all)                                   run-tests ;;
+        *)                                     printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
+    esac
+}
+
+
+if ! (return 0 2>/dev/null); then
+    main "$@"
+fi


### PR DESCRIPTION
Closes #112

### Changes

- `daylight.sh` — added `host-init()` function: runs `apt-get update` and installs baseline packages (ca-certificates, curl, git, gnupg, incus, jq, lsb-release, nginx, software-properties-common, ufw)
- `daylight.sh` — added `host-init` to case dispatch
- `tools/test-112-host-init.sh` — 3 tests, all passing