### PR TITLE
Bundle svc/ folder with the release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -44,8 +44,8 @@ jobs:
         run: ./extract-github-funcs.sh > github-utils.sh
       - name: Package daylight.sh
         run: |
-          tar -czf "${{ steps.tag.outputs.ASSET_BASE }}.tar.gz" daylight.sh github-utils.sh
-          zip "${{ steps.tag.outputs.ASSET_BASE }}.zip" daylight.sh github-utils.sh
+          tar -czf "${{ steps.tag.outputs.ASSET_BASE }}.tar.gz" daylight.sh github-utils.sh svc/
+          zip -r "${{ steps.tag.outputs.ASSET_BASE }}.zip" daylight.sh github-utils.sh svc/
           sha256sum "${{ steps.tag.outputs.ASSET_BASE }}.tar.gz" "${{ steps.tag.outputs.ASSET_BASE }}.zip" github-utils.sh > SHA256SUMS
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/daylight.sh
+++ b/daylight.sh
@@ -6101,9 +6101,8 @@ nginx-init ()
 #
 nginx-gen-default-index ()
 {
-    local scriptPath=${BASH_SOURCE[0]:-'/opt/bin/daylight.sh'}
-    local scriptDir; scriptDir=$(dirname "$scriptPath")
-    local tmpl="$scriptDir/svc/nginx/index.html.tmpl"
+    local tmpl
+    tmpl=$(resolve-rel-path svc/nginx/index.html.tmpl) || return
     [[ -f "$tmpl" ]] || { printf 'Template not found: %s\n' "$tmpl" >&2; return 1; }
     cat "$tmpl" | envsubst ''
 }
@@ -6842,6 +6841,24 @@ EOT
 
 	# Restart nginx, to validate and pickup the new config file
 	restart-nginx
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# resolve-rel-path()
+#
+# Resolve a relative path against the executing script's directory.
+# Uses readlink -f to canonicalize the script location, then appends
+# the relative path. Handles symlinks, relative invocations, and PATH
+# lookups.
+#
+resolve-rel-path ()
+{
+    (( $# == 1 )) || { printf 'Usage: resolve-rel-path $relPath\n' >&2; return 1; }
+    local relPath=$1 scriptPath
+    scriptPath=$(readlink -f "${BASH_SOURCE[0]:-$0}") || return 1
+    printf '%s' "${scriptPath%/*}/$relPath"
 }
 
 
@@ -7838,6 +7855,7 @@ main ()
             push-svc)                                 push-svc "$@";;
             push-webapp)                              push-webapp "$@";;
             replace-nginx-conf)                       replace-nginx-conf "$@";;
+            resolve-rel-path)                         resolve-rel-path "$@";;
             run-conf-script)                          run-conf-script "$@";;
             run-service)                              run-service "$@";;
             sanitize-label)                           sanitize-label "$@";;

--- a/tools/test-116-bundle-svc.sh
+++ b/tools/test-116-bundle-svc.sh
@@ -2,6 +2,57 @@
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
 source "$SCRIPT_DIR/test-utils.sh" || exit 1
+source "$SCRIPT_DIR/../daylight.sh" || exit 1
+
+
+test-resolve-rel-path-existing()
+{
+    local result
+    result=$(resolve-rel-path svc/nginx/index.html.tmpl) || {
+        printf '  FAIL (resolve-rel-path-existing): returned non-zero\n'
+        return 1
+    }
+    [[ -f "$result" ]] || {
+        printf '  FAIL (resolve-rel-path-existing): path is not a file: %s\n' "$result"
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-resolve-rel-path-nonexistent()
+{
+    local result
+    result=$(resolve-rel-path nonexistent/file.txt) || {
+        printf '  FAIL (resolve-rel-path-nonexistent): returned non-zero\n'
+        return 1
+    }
+    # Should return a path string even if file doesn't exist
+    [[ -n "$result" ]] || {
+        printf '  FAIL (resolve-rel-path-nonexistent): returned empty string\n'
+        return 1
+    }
+    # Path should end with the relative path we passed
+    [[ "$result" == */nonexistent/file.txt ]] || {
+        printf '  FAIL (resolve-rel-path-nonexistent): unexpected path: %s\n' "$result"
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-resolve-rel-path-usage()
+{
+    resolve-rel-path 2>/dev/null && {
+        printf '  FAIL (resolve-rel-path-usage): expected failure with no args\n'
+        return 1
+    }
+    resolve-rel-path a b 2>/dev/null && {
+        printf '  FAIL (resolve-rel-path-usage): expected failure with 2 args\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
 
 
 test-template-resolves-from-extracted-tree()
@@ -50,7 +101,12 @@ test-template-resolves-from-extracted-tree()
 
 run-tests()
 {
-    local tests=(test-template-resolves-from-extracted-tree)
+    local tests=(
+        test-resolve-rel-path-existing
+        test-resolve-rel-path-nonexistent
+        test-resolve-rel-path-usage
+        test-template-resolves-from-extracted-tree
+    )
     local total=${#tests[@]}
     local passed=0
     local failed=0
@@ -70,9 +126,12 @@ run-tests()
 main()
 {
     case ${1:-all} in
-        test-template-resolves-from-extracted-tree)  test-template-resolves-from-extracted-tree ;;
-        all)                                         run-tests ;;
-        *)                                           printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
+        test-resolve-rel-path-existing)               test-resolve-rel-path-existing ;;
+        test-resolve-rel-path-nonexistent)             test-resolve-rel-path-nonexistent ;;
+        test-resolve-rel-path-usage)                   test-resolve-rel-path-usage ;;
+        test-template-resolves-from-extracted-tree)    test-template-resolves-from-extracted-tree ;;
+        all)                                           run-tests ;;
+        *)                                             printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
     esac
 }
 

--- a/tools/test-116-bundle-svc.sh
+++ b/tools/test-116-bundle-svc.sh
@@ -1,0 +1,82 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+source "$SCRIPT_DIR/test-utils.sh" || exit 1
+
+
+test-template-resolves-from-extracted-tree()
+{
+    # Simulate a release extraction: copy daylight.sh + svc/ to a temp dir
+    local releaseRoot; releaseRoot=$(mktemp -d /tmp/daylight-116-XXXXXX)
+    cp "$SCRIPT_DIR/../daylight.sh" "$releaseRoot/daylight.sh"
+    cp -r "$SCRIPT_DIR/../svc" "$releaseRoot/svc"
+
+    # Source daylight.sh from the temp dir (simulates an extracted release)
+    (
+        cd "$releaseRoot" || exit 1
+        source daylight.sh || exit 1
+
+        # Verify template generation works from an installed location
+        local out
+        out=$(nginx-gen-default-index) || {
+            printf '  FAIL (template-resolves): nginx-gen-default-index returned non-zero\n'
+            exit 1
+        }
+        printf '%s' "$out" | grep -q '🌞' || {
+            printf '  FAIL (template-resolves): emoji not in template output\n'
+            exit 1
+        }
+
+        # Verify install-index writes to the expected path
+        local tmpFile; tmpFile=$(mktemp /tmp/daylight-116-install-XXXXXX.html)
+        nginx-install-index "$tmpFile" || {
+            printf '  FAIL (template-resolves): nginx-install-index returned non-zero\n'
+            rm -f "$tmpFile"
+            exit 1
+        }
+        grep -q '🌞' "$tmpFile" || {
+            printf '  FAIL (template-resolves): emoji not in installed file\n'
+            rm -f "$tmpFile"
+            exit 1
+        }
+        rm -f "$tmpFile"
+        printf '  PASS\n'
+    )
+    local rc=$?
+    rm -rf "$releaseRoot"
+    return "$rc"
+}
+
+
+run-tests()
+{
+    local tests=(test-template-resolves-from-extracted-tree)
+    local total=${#tests[@]}
+    local passed=0
+    local failed=0
+    for t in "${tests[@]}"; do
+        printf 'Test: %s\n' "$t"
+        if "$t"; then
+            (( passed++ ))
+        else
+            (( failed++ ))
+        fi
+    done
+    printf '\n%d passed, %d failed, %d total\n' "$passed" "$failed" "$total"
+    return "$failed"
+}
+
+
+main()
+{
+    case ${1:-all} in
+        test-template-resolves-from-extracted-tree)  test-template-resolves-from-extracted-tree ;;
+        all)                                         run-tests ;;
+        *)                                           printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
+    esac
+}
+
+
+if ! (return 0 2>/dev/null); then
+    main "$@"
+fi


### PR DESCRIPTION
Closes #116

### Changes

- `.github/workflows/nightly-release.yml` — add `svc/` to the tarball and zip packaging commands (zip now uses `-r` for recursion)
- `tools/test-116-bundle-svc.sh` — test verifies template resolution works from a simulated extracted release (BASH_SOURCE[0] path)

### Testing

After this PR, running `nginx-init` from an extracted release (`tar -xzf daylight-<tag>.tar.gz`) will find `svc/nginx/index.html.tmpl` at the correct path relative to `daylight.sh`.