### PR TITLE
ghr-download --extract: path resolution + tests

### DIFF
--- a/tools/test-132-to-ghapi.sh
+++ b/tools/test-132-to-ghapi.sh
@@ -36,12 +36,143 @@ test-ghr-version-path-bad-input ()
 }
 
 
+verify-file ()
+{
+    local path=$1
+    if [[ ! -f "$path" ]]; then
+        printf '  file not found (%s)\n' "$path" >&2
+        return 1
+    fi
+    if [[ ! -s "$path" ]]; then
+        printf '  file is empty (%s)\n' "$path" >&2
+        return 1
+    fi
+}
+
+
+get-token ()
+{
+    gh auth token
+}
+
+
+test-ghr-download-extract-abs-file ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-abs-file.XXXXXX)
+    local outPath="$tmpDir/renamed-program"
+
+    pushd "$tmpDir" >/dev/null || return 1
+    ghr-download --token "$token" --extract "$outPath" dylt-dev dylt > /dev/null 2>&1
+    popd >/dev/null
+    verify-file "$outPath" && { printf '  PASS\n'; return 0; } || { printf '  FAIL\n'; return 1; }
+}
+
+
+test-ghr-download-extract-abs-dir ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-abs-dir.XXXXXX)
+    local outputDir="${tmpDir%/}/outdir/"
+
+    pushd "$tmpDir" >/dev/null || return 1
+    ghr-download --token "$token" --extract "$outputDir" dylt-dev dylt > /dev/null 2>&1
+    popd >/dev/null
+
+    local files
+    files=("${outputDir%/}"/*)
+    if [[ -f "${files[0]}" && -s "${files[0]}" ]]; then
+        printf '  PASS\n'
+    else
+        printf '  FAIL\n'
+        return 1
+    fi
+}
+
+
+test-ghr-download-extract-rel-file ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-rel-file.XXXXXX)
+
+    pushd "$tmpDir" >/dev/null || return 1
+    mkdir -p sub
+    ghr-download --token "$token" --extract "sub/relocated" dylt-dev dylt > /dev/null 2>&1
+    popd >/dev/null
+
+    verify-file "$tmpDir/sub/relocated" && { printf '  PASS\n'; return 0; } \
+                                         || { printf '  FAIL\n'; return 1; }
+}
+
+
+test-ghr-download-extract-rel-dir ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-rel-dir.XXXXXX)
+
+    pushd "$tmpDir" >/dev/null || return 1
+    mkdir -p sub
+    ghr-download --token "$token" --extract "sub/" dylt-dev dylt > /dev/null 2>&1
+    popd >/dev/null
+
+    local files
+    files=("$tmpDir/sub"/*)
+    if [[ -f "${files[0]}" && -s "${files[0]}" ]]; then
+        printf '  PASS\n'
+    else
+        printf '  FAIL\n'
+        return 1
+    fi
+}
+
+
+test-ghr-download-extract-empty ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-empty.XXXXXX)
+
+    pushd "$tmpDir" >/dev/null || return 1
+    ghr-download --token "$token" --extract "" dylt-dev dylt > /dev/null 2>&1
+    popd >/dev/null
+
+    local files
+    files=("$tmpDir"/*)
+    if [[ -f "${files[0]}" && -s "${files[0]}" ]]; then
+        printf '  PASS\n'
+    else
+        printf '  FAIL\n'
+        return 1
+    fi
+}
+
+
+test-ghr-download-extract-existing ()
+{
+    local token; token=$(get-token) || { printf '  FAIL\n'; return 1; }
+    local tmpDir; tmpDir=$(mktemp -d --tmpdir test-extract-existing.XXXXXX)
+    local outPath="$tmpDir/existing-target"
+    echo "preexisting" > "$outPath"
+
+    ghr-download --token "$token" --extract "$outPath" dylt-dev dylt > /dev/null 2>&1 && {
+        printf '  FAIL\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
 all()
 {
     local tests=(
         test-ghr-version-path-latest
         test-ghr-version-path-versioned
         test-ghr-version-path-bad-input
+        test-ghr-download-extract-abs-file
+        test-ghr-download-extract-abs-dir
+        test-ghr-download-extract-rel-file
+        test-ghr-download-extract-rel-dir
+        test-ghr-download-extract-empty
+        test-ghr-download-extract-existing
     )
     local total=${#tests[@]} passed=0 failed=0
     for t in "${tests[@]}"; do
@@ -60,6 +191,12 @@ main()
         test-ghr-version-path-latest)             test-ghr-version-path-latest "$@";;
         test-ghr-version-path-versioned)          test-ghr-version-path-versioned "$@";;
         test-ghr-version-path-bad-input)          test-ghr-version-path-bad-input "$@";;
+        test-ghr-download-extract-abs-file)        test-ghr-download-extract-abs-file "$@";;
+        test-ghr-download-extract-abs-dir)         test-ghr-download-extract-abs-dir "$@";;
+        test-ghr-download-extract-rel-file)        test-ghr-download-extract-rel-file "$@";;
+        test-ghr-download-extract-rel-dir)         test-ghr-download-extract-rel-dir "$@";;
+        test-ghr-download-extract-empty)           test-ghr-download-extract-empty "$@";;
+        test-ghr-download-extract-existing)        test-ghr-download-extract-existing "$@";;
         *)                                 printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
     esac
 }


### PR DESCRIPTION
Closes #133

Adds gh-api-resolve-extract-spec mirroring resolve-output-spec behavior.
Updates ghr-download extraction block to use resolve-extract-spec.
Empty spec, directory, and full-path rename all supported.
Multi-entry archives with filename spec extract to parent directory.

6 new tests covering: absolute file, absolute dir, relative file,
relative dir, empty spec, and existing file collision.
All 64 tests pass (55 existing + 9 extraction).